### PR TITLE
solved linux issue related to using BernoulliNegative Sampler

### DIFF
--- a/torchkge/sampling.py
+++ b/torchkge/sampling.py
@@ -314,6 +314,8 @@ class BernoulliNegativeSampler(NegativeSampler):
         neg_tails = tails.repeat(n_neg)
 
         # Randomly choose which samples will have head/tail corrupted
+        
+        self.bern_probs = self.bern_probs.to(device)
         mask = bernoulli(self.bern_probs[relations].repeat(n_neg)).double()
         n_h_cor = int(mask.sum().item())
         neg_heads[mask == 1] = randint(1, self.n_ent,

--- a/torchkge/sampling.py
+++ b/torchkge/sampling.py
@@ -314,7 +314,6 @@ class BernoulliNegativeSampler(NegativeSampler):
         neg_tails = tails.repeat(n_neg)
 
         # Randomly choose which samples will have head/tail corrupted
-        
         self.bern_probs = self.bern_probs.to(device)
         mask = bernoulli(self.bern_probs[relations].repeat(n_neg)).double()
         n_h_cor = int(mask.sum().item())


### PR DESCRIPTION
It was working fine on Windows machines but it was not able to process on Linux machines.
I was not able to use CUDA with negative sampler as it was than rowing error that "indices shouldthe be on same device (CPU)". I have added one line to move the sampler to CUDA. 
This is my first contribution so let me know if I need to add more information.